### PR TITLE
Correctly get code points > U+FFFF using Array.from(str)

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,7 @@ function saslprep(input, opts = {}) {
   }
 
   // 1. Map
-  const mapped_input = input
-    .split('')
+  const mapped_input = Array.from(input)
     .map(getCodePoint)
     // 1.1 mapping to space
     .map(character => (mapping2space.get(character) ? 0x20 : character))
@@ -57,7 +56,7 @@ function saslprep(input, opts = {}) {
   // 2. Normalize
   const normalized_input = String.fromCodePoint(...mapped_input).normalize('NFKC')
 
-  const normalized_map = normalized_input.split('').map(getCodePoint)
+  const normalized_map = Array.from(normalized_input).map(getCodePoint)
 
   // 3. Prohibit
   const hasProhibited = normalized_map.some(character =>

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,11 @@ test('should work be case preserved', (t) => {
   t.is(saslprep(str), str)
 })
 
+test('should work with high code points (> U+FFFF)', (t) => {
+  const str = '\ud83d\ude00'
+  t.is(saslprep(str, {allowUnassigned: true}), str)
+})
+
 test('should remove `mapped to nothing` characters', (t) => {
   t.is(saslprep('I\u00ADX'), 'IX')
 })


### PR DESCRIPTION
This fixes issue #4. Note that use of `allowUnassigned` was needed for the test to pass, as the Emoji characters currently seem to be in the unsupported range set.