### PR TITLE
Modernizing file references to fix zeit/PKG issue

### DIFF
--- a/lib/memory-code-points.js
+++ b/lib/memory-code-points.js
@@ -5,7 +5,7 @@ const path = require('path');
 const bitfield = require('sparse-bitfield');
 
 /* eslint-disable-next-line security/detect-non-literal-fs-filename */
-const memory = fs.readFileSync(path.resolve(__dirname, '../code-points.mem'));
+const memory = fs.readFileSync(path.join(__dirname, '../code-points.mem'));
 let offset = 0;
 
 /**


### PR DESCRIPTION
When you use a builder to merge all files in an executable like [zeit/PKG](https://github.com/zeit/pkg) the `require` of the module is failing to load because `path.resolve` resolves to full-path. 

`path.join` is the best option to load external assets because it keeps the relative path and it is very useful to work properly when you have a binary package.

Maybe it solves problems with Webpack as well.